### PR TITLE
Add new function - setVirtualDesktop

### DIFF
--- a/Functions/Engines/Wine/script.js
+++ b/Functions/Engines/Wine/script.js
@@ -633,7 +633,7 @@ Wine.prototype.setSoundDriver = function (driver) {
 };
 
 /**
- * sets Virtual Desktop with resolution
+ * sets Virtual Desktop with window resolution
  * @param width {string}, height {string}
  * @returns {Wine}
  */


### PR DESCRIPTION
setVirtualDesktop = function (width, height)
Requires two variables - width and height of window.
Script creates a new enties in Windows Registry to create new Virtual Desktop with name "Default" and set up resolution with width and height variables.